### PR TITLE
Reroute to split up apps and avoid react router

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ DB_SSLMODE=disable
 PGPASSWORD=${DB_PASS}
 
 OAUTH_COOKIE_SECRET=topsecret
-OAUTH_BASE_URL=http://localhost:8080
+AUTH_BASE_URL=http://localhost:8080/auth
 OAUTH_ISSUER=https://accounts.google.com
 # The following are for the local development only, other domains will not work.
 OAUTH_CLIENT_ID=190477914499-dl3446c9h3t5k5dsidl9t1n1hnekhk3m.apps.googleusercontent.com

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ DB_SSLMODE=disable
 PGPASSWORD=${DB_PASS}
 
 OAUTH_COOKIE_SECRET=topsecret
-AUTH_BASE_URL=http://localhost:8080/auth
+OAUTH_BASE_URL=http://localhost:8080/auth
 OAUTH_ISSUER=https://accounts.google.com
 # The following are for the local development only, other domains will not work.
 OAUTH_CLIENT_ID=190477914499-dl3446c9h3t5k5dsidl9t1n1hnekhk3m.apps.googleusercontent.com

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -67,7 +67,7 @@ var cookieJar *sessions.CookieStore
 func init() {
 	cookieConfig, err := config.GetAuth()
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal("Could not load config: ", err.Error())
 	}
 	cookieJar = sessions.NewCookieStore([]byte(cookieConfig.CookieSecret))
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	oauthService "google.golang.org/api/oauth2/v2"
+	_ "github.com/joho/godotenv/autoload"
 
 	"github.com/docsocsf/sponsor-portal/config"
 )
@@ -66,7 +67,7 @@ var cookieJar *sessions.CookieStore
 func init() {
 	cookieConfig, err := config.GetAuth()
 	if err != nil {
-		log.Fatal("Could not gett cookie secret")
+		log.Fatal(err.Error())
 	}
 	cookieJar = sessions.NewCookieStore([]byte(cookieConfig.CookieSecret))
 }

--- a/client/dist/sponsors.html
+++ b/client/dist/sponsors.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Sponsor Portal</title>
-    <link rel="stylesheet" href="/assets/index.bundle.css" type="text/css" media="screen" charset="utf-8">
+    <link rel="stylesheet" href="/assets/sponsors.bundle.css" type="text/css" media="screen" charset="utf-8">
   </head>
   <body>
     <div id="app"></div>
-    <script src="/assets/index.bundle.js" charset="utf-8"></script>
+    <script src="/assets/sponsors.bundle.js" charset="utf-8"></script>
   </body>
 </html>

--- a/client/dist/students.html
+++ b/client/dist/students.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Sponsor Portal</title>
-    <link rel="stylesheet" href="/assets/index.bundle.css" type="text/css" media="screen" charset="utf-8">
+    <link rel="stylesheet" href="/assets/students.bundle.css" type="text/css" media="screen" charset="utf-8">
   </head>
   <body>
     <div id="app"></div>
-    <script src="/assets/index.bundle.js" charset="utf-8"></script>
+    <script src="/assets/students.bundle.js" charset="utf-8"></script>
   </body>
 </html>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,24 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import '../style/index.scss';
-import Home from 'Views/Home';
-import Students from 'Views/Students';
-import Sponsors from 'Views/Sponsors';
 import Login from 'Views/Login';
-import {
-  BrowserRouter as Router,
-  Route
-} from 'react-router-dom';
 
-let root = (
-  <Router>
-    <div>
-      <Route exact path="/" component={Home}/>
-      <Route path="/login" component={Login}/>
-      <Route exact path="/students/" component={Students}/>
-      <Route exact path="/sponsors/" component={Sponsors}/>
-    </div>
-  </Router>
-);
-
-ReactDOM.render(root, document.getElementById("main"));
+ReactDOM.render(<Login/>, document.getElementById("app"));

--- a/client/src/jwt.js
+++ b/client/src/jwt.js
@@ -1,8 +1,8 @@
 import memoize from 'promise-memoize';
 import fetchWithConfig from './fetch';
 
-export const generalToken = "/jwt/token"
-export const onetimeToken = "/jwt/onetime-token"
+export const generalToken = "/auth/jwt"
+export const onetimeToken = "/auth/jwt?single"
 
 export const getJWTHeader = async (hdr) => {
   const token = await getToken(generalToken);

--- a/client/src/sponsors.js
+++ b/client/src/sponsors.js
@@ -3,4 +3,4 @@ import ReactDOM from 'react-dom';
 import '../style/sponsors.scss';
 import Sponsors from 'Views/Sponsors';
 
-ReactDOM.render(<Sponsors />, document.getElementById("main"));
+ReactDOM.render(<Sponsors/>, document.getElementById("app"));

--- a/client/src/students.js
+++ b/client/src/students.js
@@ -2,23 +2,5 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import '../style/students.scss';
 import Students from 'Views/Students';
-import fetchWithConfig from './fetch';
-import { getJWTHeader } from './jwt';
 
-const endpoint = "/students/auth/jwt/token";
-
-const fetchUser = async () => {
-  const headers = await getJWTHeader(endpoint);
-  const resp = await fetchWithConfig('/students/api/user', { headers })
-
-  return resp.body
-}
-
-const fetchCV = async () => {
-  const headers = await getJWTHeader(endpoint);
-  const resp = await fetchWithConfig('/students/api/cv', { headers })
-
-  return resp.body
-}
-
-ReactDOM.render(<Students fetchUser={fetchUser} fetchCV={fetchCV}/>, document.getElementById("main"));
+ReactDOM.render(<Students/>, document.getElementById("app"));

--- a/client/src/views/Login/Login.jsx
+++ b/client/src/views/Login/Login.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Header from 'Components/Header';
 import md5 from 'md5';
 import request from 'superagent';
-import {Redirect} from 'react-router';
 
 export default class Login extends React.Component {
   constructor(props) {
@@ -11,7 +10,6 @@ export default class Login extends React.Component {
     this.state = {
       email: '',
       password: '',
-      redirect: undefined
     };
   }
 
@@ -21,12 +19,12 @@ export default class Login extends React.Component {
     password = md5(password)
     try {
       let resp = await request
-        .post('/sponsors/auth/login')
+        .post('/auth/sponsors/login')
         .type('form')
         .send({ email })
         .send({ password })
       let redirect = new URL(resp.xhr.responseURL).pathname;
-      this.setState({redirect});
+      window.location.replace(redirect)
     } catch (e) {
       console.log(e);
       this.setState({error: "The email and/or password you entered was incorrect"});
@@ -36,10 +34,7 @@ export default class Login extends React.Component {
   handleChange = (event) => this.setState({ [event.target.name]: event.target.value })
 
   render() {
-    let {redirect, error, email, password } = this.state;
-    if (!!redirect) {
-      return (<Redirect to={redirect} />);
-    }
+    let {error, email, password } = this.state;
 
     return (
       <div>

--- a/client/src/views/Sponsors/actions.js
+++ b/client/src/views/Sponsors/actions.js
@@ -6,12 +6,12 @@ export const fetchCVs = async () => {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   });
-  let resp = await fetchWithConfig('/sponsors/api/cvs', { headers })
+  let resp = await fetchWithConfig('/api/sponsors/cvs', { headers })
   return resp.body;
 }
 
 export const downloadCV = async id => {
-    const endpoint = `/sponsors/api/cv/${id}/download?token=`;
+  const endpoint = `/api/sponsors/cv/${id}/download?token=`;
     const token = await getToken(onetimeToken);
     window.location.href = `${endpoint}${token}`;
 }

--- a/client/src/views/Students/StudentProfile.jsx
+++ b/client/src/views/Students/StudentProfile.jsx
@@ -47,7 +47,7 @@ export default class StudentProfile extends React.Component {
 
     try {
       let data = await request
-        .post('/students/api/cv')
+        .post('/api/students/cv')
         .set(headers)
         .attach('cv', files[0]).
         on('progress', event => {

--- a/client/src/views/Students/index.js
+++ b/client/src/views/Students/index.js
@@ -6,13 +6,13 @@ import StudentProfile from './StudentProfile';
 
 const fetchUser = async () => {
   const headers = await getJWTHeader();
-  let resp = await fetchWithConfig('/students/api/user', { headers })
+  let resp = await fetchWithConfig('/api/students/user', { headers })
   return resp.body
 }
 
 const fetchCV = async () => {
   const headers = await getJWTHeader();
-  let resp = await fetchWithConfig('/students/api/cv', { headers })
+  let resp = await fetchWithConfig('/api/students/cv', { headers })
   return resp.body
 }
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -12,6 +12,8 @@ const polyfill = (...files) => ["babel-polyfill", ...files];
 module.exports = {
   entry: {
     index: polyfill("./src/index.js"),
+    students: polyfill("./src/students.js"),
+    sponsors: polyfill("./src/sponsors.js"),
   },
   output: {
     path: path.resolve("dist/assets"),

--- a/config/auth.go
+++ b/config/auth.go
@@ -5,7 +5,7 @@ import "github.com/caarlos0/env"
 type OAuth struct {
 	CookieSecret string `env:"OAUTH_COOKIE_SECRET,required"`
 
-	BaseURL string `env:"AUTH_BASE_URL"`
+	BaseURL string `env:"OAUTH_BASE_URL"`
 	Issuer  string `env:"OAUTH_ISSUER"`
 
 	ClientID     string `env:"OAUTH_CLIENT_ID,required"`

--- a/config/auth.go
+++ b/config/auth.go
@@ -5,7 +5,7 @@ import "github.com/caarlos0/env"
 type OAuth struct {
 	CookieSecret string `env:"OAUTH_COOKIE_SECRET,required"`
 
-	BaseURL string `env:"OAUTH_BASE_URL"`
+	BaseURL string `env:"AUTH_BASE_URL"`
 	Issuer  string `env:"OAUTH_ISSUER"`
 
 	ClientID     string `env:"OAUTH_CLIENT_ID,required"`

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -8,12 +8,9 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type Api struct {
-	router *mux.Router
-}
-
-func NewApi(r *mux.Router, students *student.Service, sponsors *sponsor.Service) *Api {
-	r.PathPrefix("/students/").Handler(http.StripPrefix("/api/students", students.GetApiRoutes()))
-	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/api/sponsors", sponsors.GetApiRoutes()))
-	return &Api{r}
+func Api(students *student.Service, sponsors *sponsor.Service) http.Handler {
+	r := mux.NewRouter()
+	r.PathPrefix("/students/").Handler(http.StripPrefix("/students", students.GetApiRoutes()))
+	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/sponsors", sponsors.GetApiRoutes()))
+	return r
 }

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/docsocsf/sponsor-portal/sponsor"
+	"github.com/docsocsf/sponsor-portal/student"
+	"github.com/gorilla/mux"
+)
+
+type Api struct {
+	router *mux.Router
+}
+
+func NewApi(r *mux.Router, students *student.Service, sponsors *sponsor.Service) *Api {
+	r.PathPrefix("/students/").Handler(http.StripPrefix("/api/students", students.GetApiRoutes()))
+	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/api/sponsors", sponsors.GetApiRoutes()))
+	return &Api{r}
+}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -10,15 +10,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type Auth struct {
-	router *mux.Router
-}
-
-func NewAuth(r *mux.Router, students *student.Service, sponsors *sponsor.Service) *Auth {
+func Auth(students *student.Service, sponsors *sponsor.Service) http.Handler {
+	r := mux.NewRouter()
 	r.HandleFunc("/jwt", getJwt)
-	r.PathPrefix("/students/").Handler(http.StripPrefix("/auth/students", students.Auth.Handler()))
-	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/auth/sponsors", sponsors.Auth.Handler()))
-	return &Auth{r}
+	r.PathPrefix("/students/").Handler(http.StripPrefix("/students", students.Auth.Handler()))
+	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/sponsors", sponsors.Auth.Handler()))
+	return r
 }
 
 func getJwt(w http.ResponseWriter, r *http.Request) {

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/docsocsf/sponsor-portal/auth"
+	"github.com/docsocsf/sponsor-portal/sponsor"
+	"github.com/docsocsf/sponsor-portal/student"
+	"github.com/egnwd/roles"
+	"github.com/gorilla/mux"
+)
+
+type Auth struct {
+	router *mux.Router
+}
+
+func NewAuth(r *mux.Router, students *student.Service, sponsors *sponsor.Service) *Auth {
+	r.HandleFunc("/jwt", getJwt)
+	r.PathPrefix("/students/").Handler(http.StripPrefix("/auth/students", students.Auth.Handler()))
+	r.PathPrefix("/sponsors/").Handler(http.StripPrefix("/auth/sponsors", sponsors.Auth.Handler()))
+	return &Auth{r}
+}
+
+func getJwt(w http.ResponseWriter, r *http.Request) {
+	vs, ok := r.URL.Query()["single"]
+	single := ok && len(vs) > 0
+	h := auth.RequireAuth(auth.GetToken(single), "/", roles.Anyone)
+	h.ServeHTTP(w, r)
+}

--- a/handlers/log.go
+++ b/handlers/log.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gorilla/handlers"
+)
+
+func LoggingHandler(w io.Writer, h http.Handler) http.Handler {
+	return handlers.LoggingHandler(w, h)
+}

--- a/httputils/redirect.go
+++ b/httputils/redirect.go
@@ -1,0 +1,23 @@
+package httputils
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func Redirect(w http.ResponseWriter, r *http.Request, to string) {
+	newUri, err := url.Parse(to)
+	if err != nil {
+		http.Error(w, "Failed to parse redirect path", http.StatusInternalServerError)
+		return
+	}
+
+	baseUri, err := url.Parse(r.RequestURI)
+	if err != nil {
+		http.Error(w, "Failed to parse redirect base", http.StatusInternalServerError)
+		return
+	}
+
+	path := baseUri.ResolveReference(newUri).String()
+	http.Redirect(w, r, path, http.StatusSeeOther)
+}

--- a/sponsor/auth.go
+++ b/sponsor/auth.go
@@ -3,9 +3,9 @@ package sponsor
 import (
 	"errors"
 	"net/http"
-	"net/url"
 
 	"github.com/docsocsf/sponsor-portal/auth"
+	"github.com/docsocsf/sponsor-portal/httputils"
 	"github.com/docsocsf/sponsor-portal/model"
 	"github.com/egnwd/roles"
 )
@@ -63,7 +63,7 @@ func (s *Service) authHandler(info auth.UserInfo) (*auth.UserIdentifier, error) 
 }
 
 func (s *Service) authSuccessHandler(w http.ResponseWriter, r *http.Request) {
-	redirect(w, r, "/sponsors/")
+	httputils.Redirect(w, r, "/sponsors/")
 }
 
 func (s *Service) authFailureHandler(w http.ResponseWriter, r *http.Request) {
@@ -71,23 +71,5 @@ func (s *Service) authFailureHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) authPostLogoutHandler(w http.ResponseWriter, r *http.Request) {
-	redirect(w, r, "/")
-}
-
-// TODO: dedupe
-func redirect(w http.ResponseWriter, r *http.Request, to string) {
-	newUri, err := url.Parse(to)
-	if err != nil {
-		http.Error(w, "Failed to parse redirect path", http.StatusInternalServerError)
-		return
-	}
-
-	baseUri, err := url.Parse(r.RequestURI)
-	if err != nil {
-		http.Error(w, "Failed to parse redirect base", http.StatusInternalServerError)
-		return
-	}
-
-	path := baseUri.ResolveReference(newUri).String()
-	http.Redirect(w, r, path, http.StatusSeeOther)
+	httputils.Redirect(w, r, "/")
 }

--- a/sponsor/auth.go
+++ b/sponsor/auth.go
@@ -10,10 +10,10 @@ import (
 	"github.com/egnwd/roles"
 )
 
-const role = "sponsor"
+const Role = "sponsor"
 
 func init() {
-	roles.Register(role, auth.RoleChecker(role))
+	roles.Register(Role, auth.RoleChecker(Role))
 }
 
 func (s *Service) setupAuth(config *auth.Config) (err error) {
@@ -57,7 +57,7 @@ func (s *Service) authHandler(info auth.UserInfo) (*auth.UserIdentifier, error) 
 		return nil, err
 	}
 
-	id := auth.UserIdentifier{user.Id, role}
+	id := auth.UserIdentifier{user.Id, Role}
 
 	return &id, nil
 }

--- a/sponsor/routes.go
+++ b/sponsor/routes.go
@@ -12,11 +12,11 @@ func (s *Service) GetApiRoutes() http.Handler {
 	get := api.Methods(http.MethodGet).Subrouter()
 
 	get.Handle("/cvs",
-		auth.RequireJWT(http.HandlerFunc(s.getCVs), s.Auth, role),
+		auth.RequireJWT(http.HandlerFunc(s.getCVs), s.Auth, Role),
 	)
 
 	get.Handle("/cv/{id:[0-9]+}/download",
-		auth.RequireOnetimeJWT(http.HandlerFunc(s.downloadCV), s.Auth, role),
+		auth.RequireOnetimeJWT(http.HandlerFunc(s.downloadCV), s.Auth, Role),
 	)
 
 	return api

--- a/sponsor/routes.go
+++ b/sponsor/routes.go
@@ -7,15 +7,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *Service) defineRoutes(r *mux.Router, web http.Handler) {
-	// auth
-	r.PathPrefix("/auth").Handler(http.StripPrefix("/sponsors/auth", s.Auth.Handler()))
-
-	r.Handle("/", auth.RequireAuth(web, "/login", role))
-	r.PathPrefix("/api").Handler(http.StripPrefix("/sponsors/api", s.getApiRoutes()))
-}
-
-func (s *Service) getApiRoutes() http.Handler {
+func (s *Service) GetApiRoutes() http.Handler {
 	api := mux.NewRouter()
 	get := api.Methods(http.MethodGet).Subrouter()
 

--- a/sponsor/service.go
+++ b/sponsor/service.go
@@ -1,12 +1,9 @@
 package sponsor
 
 import (
-	"net/http"
-
 	"github.com/docsocsf/sponsor-portal/auth"
 	"github.com/docsocsf/sponsor-portal/config"
 	"github.com/docsocsf/sponsor-portal/model"
-	"github.com/gorilla/mux"
 )
 
 type Service struct {
@@ -45,8 +42,4 @@ func (s *Service) SetupDatabase(dbConfig config.Database) error {
 
 func (s *Service) SetupStorer(s3Config config.S3) {
 	s.s3 = model.NewS3(s3Config.Aws, s3Config.Bucket, s3Config.Prefix)
-}
-
-func (s *Service) Handle(r *mux.Router, web http.Handler) {
-	s.defineRoutes(r.PathPrefix("/sponsors").Subrouter(), web)
 }

--- a/student/auth.go
+++ b/student/auth.go
@@ -9,10 +9,10 @@ import (
 	"github.com/egnwd/roles"
 )
 
-const role = "student"
+const Role = "student"
 
 func init() {
-	roles.Register(role, auth.RoleChecker(role))
+	roles.Register(Role, auth.RoleChecker(Role))
 }
 
 func (s *Service) setupAuth(config *auth.Config) (err error) {
@@ -48,7 +48,7 @@ func (s *Service) authHandler(info auth.UserInfo) (*auth.UserIdentifier, error) 
 		return nil, err
 	}
 
-	id := auth.UserIdentifier{user.Id, role}
+	id := auth.UserIdentifier{user.Id, Role}
 
 	return &id, nil
 }

--- a/student/auth.go
+++ b/student/auth.go
@@ -2,9 +2,9 @@ package student
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/docsocsf/sponsor-portal/auth"
+	"github.com/docsocsf/sponsor-portal/httputils"
 	"github.com/docsocsf/sponsor-portal/model"
 	"github.com/egnwd/roles"
 )
@@ -54,7 +54,7 @@ func (s *Service) authHandler(info auth.UserInfo) (*auth.UserIdentifier, error) 
 }
 
 func (s *Service) authSuccessHandler(w http.ResponseWriter, r *http.Request) {
-	redirect(w, r, "/students")
+	httputils.Redirect(w, r, "/students")
 }
 
 func (s *Service) authFailureHandler(w http.ResponseWriter, r *http.Request) {
@@ -62,22 +62,5 @@ func (s *Service) authFailureHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) authPostLogoutHandler(w http.ResponseWriter, r *http.Request) {
-	redirect(w, r, "/")
-}
-
-func redirect(w http.ResponseWriter, r *http.Request, to string) {
-	newUri, err := url.Parse(to)
-	if err != nil {
-		http.Error(w, "Failed to parse redirect path", http.StatusInternalServerError)
-		return
-	}
-
-	baseUri, err := url.Parse(r.RequestURI)
-	if err != nil {
-		http.Error(w, "Failed to parse redirect base", http.StatusInternalServerError)
-		return
-	}
-
-	path := baseUri.ResolveReference(newUri).String()
-	http.Redirect(w, r, path, http.StatusSeeOther)
+	httputils.Redirect(w, r, "/")
 }

--- a/student/routes.go
+++ b/student/routes.go
@@ -14,5 +14,5 @@ func (s *Service) GetApiRoutes() http.Handler {
 	api.HandleFunc("/cv", s.uploadCV).Methods(http.MethodPost)
 	api.HandleFunc("/cv", s.getCV).Methods(http.MethodGet)
 
-	return auth.RequireJWT(api, s.Auth, role)
+	return auth.RequireJWT(api, s.Auth, Role)
 }

--- a/student/routes.go
+++ b/student/routes.go
@@ -7,15 +7,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *Service) defineRoutes(r *mux.Router, web http.Handler) {
-	// auth
-	r.PathPrefix("/auth").Handler(http.StripPrefix("/students/auth", s.Auth.Handler()))
-
-	r.Handle("/", auth.RequireAuth(web, "/students/auth/login", role))
-	r.PathPrefix("/api").Handler(http.StripPrefix("/students/api", s.getApiRoutes()))
-}
-
-func (s *Service) getApiRoutes() http.Handler {
+func (s *Service) GetApiRoutes() http.Handler {
 	api := mux.NewRouter()
 
 	api.HandleFunc("/user", s.getUserInformation)

--- a/student/service.go
+++ b/student/service.go
@@ -1,12 +1,9 @@
 package student
 
 import (
-	"net/http"
-
 	"github.com/docsocsf/sponsor-portal/auth"
 	"github.com/docsocsf/sponsor-portal/config"
 	"github.com/docsocsf/sponsor-portal/model"
-	"github.com/gorilla/mux"
 )
 
 type Service struct {
@@ -47,8 +44,4 @@ func (s *Service) SetupDatabase(dbConfig config.Database) error {
 	s.CVWriter = model.NewCVWriter(db)
 
 	return nil
-}
-
-func (s *Service) Handle(r *mux.Router, web http.Handler) {
-	s.defineRoutes(r.PathPrefix("/students").Subrouter(), web)
 }

--- a/web/main.go
+++ b/web/main.go
@@ -29,8 +29,8 @@ func main() {
 	studentService := makeStudentService(host.StaticFiles)
 	sponsorService := makeSponsorService(host.StaticFiles)
 
-	handlers.NewApi(r.PathPrefix("/api/").Subrouter(), studentService, sponsorService)
-	handlers.NewAuth(r.PathPrefix("/auth/").Subrouter(), studentService, sponsorService)
+	r.PathPrefix("/api/").Handler(http.StripPrefix("/api", handlers.Api(studentService, sponsorService)))
+	r.PathPrefix("/auth/").Handler(http.StripPrefix("/auth", handlers.Auth(studentService, sponsorService)))
 
 	assets := http.FileServer(http.Dir(host.StaticFiles))
 	r.PathPrefix("/assets").Handler(assets)

--- a/web/main.go
+++ b/web/main.go
@@ -7,9 +7,12 @@ import (
 	"path"
 	"strings"
 
+	"github.com/docsocsf/sponsor-portal/auth"
 	"github.com/docsocsf/sponsor-portal/config"
 	"github.com/docsocsf/sponsor-portal/handlers"
 	"github.com/docsocsf/sponsor-portal/httputils"
+	"github.com/docsocsf/sponsor-portal/sponsor"
+	"github.com/docsocsf/sponsor-portal/student"
 	"github.com/gorilla/mux"
 	_ "github.com/joho/godotenv/autoload"
 )
@@ -23,11 +26,11 @@ func main() {
 
 	r := mux.NewRouter().StrictSlash(true)
 
-	student := makeStudentService(host.StaticFiles)
-	sponsor := makeSponsorService(host.StaticFiles)
+	studentService := makeStudentService(host.StaticFiles)
+	sponsorService := makeSponsorService(host.StaticFiles)
 
-	handlers.NewApi(r.PathPrefix("/api/").Subrouter(), student, sponsor)
-	handlers.NewAuth(r.PathPrefix("/auth/").Subrouter(), student, sponsor)
+	handlers.NewApi(r.PathPrefix("/api/").Subrouter(), studentService, sponsorService)
+	handlers.NewAuth(r.PathPrefix("/auth/").Subrouter(), studentService, sponsorService)
 
 	assets := http.FileServer(http.Dir(host.StaticFiles))
 	r.PathPrefix("/assets").Handler(assets)
@@ -36,8 +39,8 @@ func main() {
 		httputils.Redirect(w, r, "/login")
 	})
 	r.Handle("/login", file(host.StaticFiles, "index.html"))
-	r.Handle("/students", file(host.StaticFiles, "students.html"))
-	r.Handle("/sponsors", file(host.StaticFiles, "sponsors.html"))
+	r.Handle("/students", auth.RequireAuth(file(host.StaticFiles, "students.html"), "/login", student.Role))
+	r.Handle("/sponsors", auth.RequireAuth(file(host.StaticFiles, "sponsors.html"), "/login", sponsor.Role))
 
 	log.Printf("Listening on %s...", host.Port)
 	log.Fatal(http.ListenAndServe(host.Port, handlers.LoggingHandler(os.Stdout, r)))

--- a/web/sponsors.go
+++ b/web/sponsors.go
@@ -15,7 +15,7 @@ func makeSponsorService(staticFiles string) *sponsor.Service {
 	}
 
 	authConfig := &auth.Config{
-		BaseURL:      authEnvConfig.BaseURL,
+		BaseURL:      authEnvConfig.BaseURL + "/sponsors",
 		Issuer:       authEnvConfig.Issuer,
 		ClientID:     authEnvConfig.ClientID,
 		ClientSecret: authEnvConfig.ClientSecret,

--- a/web/students.go
+++ b/web/students.go
@@ -15,7 +15,7 @@ func makeStudentService(staticFiles string) *student.Service {
 	}
 
 	authConfig := &auth.Config{
-		BaseURL:      authEnvConfig.BaseURL + "/students/auth",
+		BaseURL:      authEnvConfig.BaseURL + "/students",
 		Issuer:       authEnvConfig.Issuer,
 		ClientID:     authEnvConfig.ClientID,
 		ClientSecret: authEnvConfig.ClientSecret,


### PR DESCRIPTION
Update routes to make more sense, splitting the react app routes from the api and auth