### PR TITLE
Make the Makefile commands more intuitive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,21 @@ seed:
 
 setup: install setupdb seed
 
-build:
+client:
 	cd client; yarn build
 
-build-dev:
+client-dev:
 	cd client; yarn build:dev
 
-client:
-	cd client; yarn && yarn start
+watch:
+	cd client; yarn start
 
 server:
-	go run web/*.go
+	go build -o sponsor-portal ./web
+
+run: server
+	./sponsor-portal
+
+.PHONY: install setupdb seed setup
+.PHONY: client client-dev watch
+.PHONY: server run

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@
  - `make install` to install npm and go packages
  - `docker-compose up -d` and `make setup` to start docker and migrate/seed the db
  
- - `make client` to build the front-end assets for development and watch for changes (recommended)
- - `make build-dev` to build the front-end assets for development
- - `make build` to build the front-end assets for production
+ - `make client` to build the front-end assets for production
+ - `make client-dev` to build the front-end assets for development
+ - `make watch` to build the front-end assets for development and watch for changes (recommended)
 
- - `make server` to start the go server
- 
+ - `make server` to build the server
+ - `make run` to start the server
+
 ## Example sponsor
 
  - Email: `ada@sponsor.com`


### PR DESCRIPTION
`make client` and `make server` only build, they don’t start any long
running process. `make watch` and `make run` can be used for these.

Also .PHONY all targets